### PR TITLE
Fix V shaped propagation

### DIFF
--- a/ACMM.cu
+++ b/ACMM.cu
@@ -777,14 +777,14 @@ __device__ void CheckerboardPropagation(const cudaTextureObject_t *images, const
         costMinPoint = up_near;
         for (int i = 0; i < 3; ++i) {
             if (p.y > 1 + i && p.x > i) {
-                int pointTemp = up_near - (1 + i) * width - i;
+                int pointTemp = up_near - (1 + i) * width - (1 + i);
                 if (costs[pointTemp] < costMin) {
                     costMin = costs[pointTemp];
                     costMinPoint = pointTemp;
                 }
             }
             if (p.y > 1 + i && p.x < width - 1 - i) {
-                int pointTemp = up_near - (1 + i) * width + i;
+                int pointTemp = up_near - (1 + i) * width + (1 + i);
                 if (costs[pointTemp] < costMin) {
                     costMin = costs[pointTemp];
                     costMinPoint = pointTemp;
@@ -803,14 +803,14 @@ __device__ void CheckerboardPropagation(const cudaTextureObject_t *images, const
         costMinPoint = down_near;
         for (int i = 0; i < 3; ++i) {
             if (p.y < height - 2 - i && p.x > i) {
-                int pointTemp = down_near + (1 + i) * width - i;
+                int pointTemp = down_near + (1 + i) * width - (1 + i);
                 if (costs[pointTemp] < costMin) {
                     costMin = costs[pointTemp];
                     costMinPoint = pointTemp;
                 }
             }
             if (p.y < height - 2 - i && p.x < width - 1 - i) {
-                int pointTemp = down_near + (1 + i) * width + i;
+                int pointTemp = down_near + (1 + i) * width + (1 + i);
                 if (costs[pointTemp] < costMin) {
                     costMin = costs[pointTemp];
                     costMinPoint = pointTemp;
@@ -829,14 +829,14 @@ __device__ void CheckerboardPropagation(const cudaTextureObject_t *images, const
         costMinPoint = left_near;
         for (int i = 0; i < 3; ++i) {
             if (p.x > 1 + i && p.y > i) {
-                int pointTemp = left_near - (1 + i) - i * width;
+                int pointTemp = left_near - (1 + i) - (1 + i) * width;
                 if (costs[pointTemp] < costMin) {
                     costMin = costs[pointTemp];
                     costMinPoint = pointTemp;
                 }
             }
             if (p.x > 1 + i && p.y < height - 1 - i) {
-                int pointTemp = left_near - (1 + i) + i * width;
+                int pointTemp = left_near - (1 + i) + (1 + i) * width;
                 if (costs[pointTemp] < costMin) {
                     costMin = costs[pointTemp];
                     costMinPoint = pointTemp;
@@ -855,14 +855,14 @@ __device__ void CheckerboardPropagation(const cudaTextureObject_t *images, const
         costMinPoint = right_near;
         for (int i = 0; i < 3; ++i) {
             if (p.x < width - 2 - i && p.y > i) {
-                int pointTemp = right_near + (1 + i) - i * width;
+                int pointTemp = right_near + (1 + i) - (1 + i) * width;
                 if (costs[pointTemp] < costMin) {
                     costMin = costs[pointTemp];
                     costMinPoint = pointTemp;
                 }
             }
             if (p.x < width - 2 - i && p.y < height - 1- i) {
-                int pointTemp = right_near + (1 + i) + i * width;
+                int pointTemp = right_near + (1 + i) + (1 + i) * width;
                 if (costs[pointTemp] < costMin) {
                     costMin = costs[pointTemp];
                     costMinPoint = pointTemp;


### PR DESCRIPTION
For propagation of red pixels, the current impl is actually using red pixels (supposed to be black) for the V-shaped comparison. 

For e.g. `left_near`, let's assume center pixel is red.
Current Impl - `int pointTemp = left_near - (1 + i) - i * width;`
Here `left_near` is pixel on the left of center pixel, so it is black pixel.
then for `i==0`, `pointTemp` resolves to  `left_near - 1`, which is again red, same as center pixel.

This is fixed in this PR.
